### PR TITLE
Use source instead of eval

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -46,12 +46,12 @@ Now that silver is configured, you need to evaluate its bootstrap code.
 
 `~/.bashrc`/`~/.zshrc`:
 ```sh
-eval "$(silver init)"
+source <(silver init)
 ```
 
 `~/.config/fish/config.fish`:
 ```fish
-eval (silver init)
+silver init | source
 ```
 
 ## Documentation


### PR DESCRIPTION
You should prefer source over eval if your code doesn't read from stdin